### PR TITLE
 Added dark mode toggle with persistent theme and UI improvements

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,7 +22,6 @@
 <body class="bg-slate-50 text-slate-800">
 
     <div id="app" class="flex flex-col md:flex-row h-screen w-screen overflow-hidden">
-        
         <!-- Controls Panel -->
         <div class="w-full md:w-80 lg:w-96 bg-white border-r border-slate-200 p-6 flex flex-col space-y-6 overflow-y-auto control-panel">
             <header>
@@ -125,6 +124,9 @@
             </div>
         </div>
     </div>
+
+<!-- 🌙 Floating Dark Mode Button -->
+    <button id="darkModeToggle" title="Toggle Dark Mode">🌙</button>
 
     <script src="script.js"></script>
 </body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "poster-designer",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "poster-designer",
+      "version": "1.0.0",
+      "license": "ISC"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "poster-designer",
+  "version": "1.0.0",
+  "description": "Design your perfect wall poster layout with ease. The **AI Wall Poster Planner** is a simple, web-based tool that helps you customize, visualize, and organize your wall posters before you ever hang them up.",
+  "main": "script.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/p0ized/poster-designer.git"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "bugs": {
+    "url": "https://github.com/p0ized/poster-designer/issues"
+  },
+  "homepage": "https://github.com/p0ized/poster-designer#readme"
+}

--- a/script.js
+++ b/script.js
@@ -325,12 +325,28 @@ document.addEventListener('DOMContentLoaded', () => {
         exportImageBtn.addEventListener('click', exportWallAsImage);
 
         wallColorInput.addEventListener('input', () => {
-            wall.style.backgroundColor = wallColorInput.value;
-        });
-        
+      const color = wallColorInput.value;
+      wall.style.backgroundColor = color;
+      wall.style.setProperty('--wall-color', color); // ✅ this keeps wall color consistent in dark mode
+     });
         const resizeObserver = new ResizeObserver(() => render());
         resizeObserver.observe(canvasContainer);
         
         updateWallDimensions();
         render();
+        // 🌙 DARK MODE TOGGLE
+const darkModeToggle = document.getElementById('darkModeToggle');
+
+// Apply saved theme
+if (localStorage.getItem('theme') === 'dark') {
+    document.body.classList.add('dark');
+}
+
+// Toggle theme on click
+darkModeToggle.addEventListener('click', () => {
+    document.body.classList.toggle('dark');
+    localStorage.setItem('theme', document.body.classList.contains('dark') ? 'dark' : 'light');
+});
+
     });
+

--- a/style.css
+++ b/style.css
@@ -45,4 +45,73 @@
         .control-panel::-webkit-scrollbar-thumb:hover {
             background: #94a3b8;
         }
-    
+/* Normal light mode styles */
+body {
+  background-color: #fff;
+  color: #000;
+  font-family: sans-serif;
+}
+
+/* 🌙 Dark Mode Styles (Improved) */
+
+/* Only UI darkens, not the wall */
+body.dark {
+  background-color: #121212;
+  color: #e0e0e0;
+}
+
+/* Panel dark mode */
+body.dark .control-panel {
+  background-color: #1e1e1e;
+}
+
+/* Inputs and dropdowns */
+body.dark input,
+body.dark select,
+body.dark textarea {
+  background-color: #222;
+  color: #eee;
+  border: 1px solid #555;
+}
+
+/* ✅ Wall keeps its custom color in dark mode */
+body.dark #wall {
+  background-color: var(--wall-color, inherit) !important;
+}
+
+/* Buttons */
+body.dark button {
+  background-color: #444;
+  color: #fff;
+}
+
+/* 🌙 Small Floating Dark Mode Button */
+#darkModeToggle {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  border: none;
+  background-color: #333;
+  color: #fff;
+  font-size: 16px;
+  cursor: pointer;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.3);
+  transition: all 0.3s ease;
+  z-index: 1000;
+}
+
+#darkModeToggle:hover {
+  background-color: #555;
+}
+
+body.dark #darkModeToggle {
+  background-color: #eee;
+  color: #000;
+}
+
+body.dark #canvasContainer {
+  background-color: #121212; /* dark surroundings */
+}


### PR DESCRIPTION
This pull request adds a Dark Mode toggle feature to the Poster Designer web app.
Users can now switch between light and dark themes seamlessly, and their preference is saved in localStorage, ensuring consistency across sessions.

🌙 Key Changes

Added a floating dark mode toggle button (🌙) at the bottom-right corner of the UI.

Implemented persistent theme handling using localStorage.

Introduced new CSS styles for dark mode (inputs, buttons, and panels).

Updated JS logic to handle dynamic theme toggling.

Ensured the poster wall color remains consistent across both themes.

🧩 Files Modified

index.html

style.css

script.js

🧪 Testing

Verified theme toggle works smoothly across reloads.

Checked that custom wall colors remain unaffected in dark mode.

Ensured all layout and export features still function properly.
<img width="1912" height="917" alt="dark mode" src="https://github.com/user-attachments/assets/e7f30b4b-8b5e-41a6-9c25-c5018955b1cc" />
